### PR TITLE
Add findomain subdomain scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN go get -v github.com/projectdiscovery/subfinder/cmd/subfinder && \
 	go get -v github.com/OWASP/Amass/v3/... && \
 	go get -u github.com/tomnomnom/assetfinder
 
+RUN wget https://github.com/Edu4rdSHL/findomain/releases/latest/download/findomain-linux && \
+	chmod +x findomain-linux
+
 RUN mkdir results && \
 	wget https://raw.githubusercontent.com/Anon-Exploiter/subdomainsEnumerator/master/automateSubdEnumv2.sh
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently integrated tools include:
 * [OneForAll](https://github.com/shmilylty/OneForAll/)
 * [Asset Finder](https://github.com/tomnomnom/assetfinder)
 * [MassDNS](https://github.com/blechschmidt/massdns)
+* [Findomain](https://github.com/Edu4rdSHL/findomain)
 
 ## Contribution
 Want to add another tools? If you can, make a PR editing the bash file containing script's args etc. & Dockerfile containing the cloning and setting up. 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Currently integrated tools include:
 * [Amass](https://github.com/OWASP/Amass)
 * [OneForAll](https://github.com/shmilylty/OneForAll/)
 * [Asset Finder](https://github.com/tomnomnom/assetfinder)
-* [MassDNS](https://github.com/blechschmidt/massdns)
 * [Findomain](https://github.com/Edu4rdSHL/findomain)
+* [MassDNS](https://github.com/blechschmidt/massdns)
 
 ## Contribution
 Want to add another tools? If you can, make a PR editing the bash file containing script's args etc. & Dockerfile containing the cloning and setting up. 

--- a/automateSubdEnumv2.sh
+++ b/automateSubdEnumv2.sh
@@ -16,6 +16,7 @@ subfinderPATH=./results/$HOST-subfinder.txt
 amassPATH=./results/$HOST-amass.txt
 oneForAllPATH=../results/
 assetfinderPATH=./results/$HOST-assetfinder.txt
+finddomainPATH=./results/$HOST-findomain.txt
 
 ##
 
@@ -56,6 +57,13 @@ function automateAssetsFinder() {
 	assetfinder --subs-only $HOST | tee $assetfinderPATH
 }
 
+function automateFindomain() {
+	echo -e "\n$bar\n\tRunning Findomain\n$bar\n"
+	cd $mainPATH
+	./findomain-linux -t $HOST -u $finddomainPATH
+
+}
+
 function sortResults() {
 	cd $mainPATH
 	cd results/
@@ -81,6 +89,8 @@ automateSubfinder $HOST
 automateAmass $HOST
 automateOneForAll $HOST
 automateAssetsFinder $HOST
+automateFindomain $HOST
+
 
 sortResults
 resolveSubdomains


### PR DESCRIPTION
## Description

Add findomain tool in the list of subdomain scanning tools

## Motivation

Find domain scans domains from multiple sources and has the capability to add domains into the database which can be later used for monitoring, for now, I have only added single domain search using findomain.
